### PR TITLE
add locate and locate! methods to MadID to make raising errors optional

### DIFF
--- a/lib/mad_id.rb
+++ b/lib/mad_id.rb
@@ -15,8 +15,17 @@ module MadID
     attr_accessor :registry
 
     def locate(id)
-      prefix, _ = id.split('-', 2)
-      registry[prefix].find_by_mad_id!(id)
+      prefix, _ = id.to_s.split('-', 2)
+      if klass = registry[prefix]
+        klass.find_by_mad_id(id)
+      else
+        nil
+      end
+    end
+
+    def locate!(id)
+      prefix, _ = id.to_s.split('-', 2)
+      registry.fetch(prefix).find_by_mad_id!(id)
     end
   end
 

--- a/lib/mad_id/finder_methods.rb
+++ b/lib/mad_id/finder_methods.rb
@@ -3,5 +3,8 @@ module MadID::FinderMethods
   def find_by_mad_id!(id)
     find_by!(identifier: id.to_s.downcase)
   end
+  def find_by_mad_id(id)
+    find_by(identifier: id.to_s.downcase)
+  end
 
 end

--- a/spec/mad_id_spec.rb
+++ b/spec/mad_id_spec.rb
@@ -81,14 +81,31 @@ describe MadID do
     let!(:little_pony) { LittlePony.create }
     let!(:great_pony) { GreatPony.create }
 
-    it 'locate the little pony just by the identifier' do
-      expect(MadID.locate(little_pony.identifier)).to eq(little_pony)
-    end
+    describe 'locate' do
+      it 'locate the little pony just by the identifier' do
+        expect(MadID.locate(little_pony.identifier)).to eq(little_pony)
+      end
 
-    it 'locate the great pony just by the identifier' do
-      binding
-      expect(MadID.locate(great_pony.identifier)).to eq(great_pony)
-    end
+      it 'locate the great pony just by the identifier' do
+        expect(MadID.locate(great_pony.identifier)).to eq(great_pony)
+      end
 
+      it 'returns nil if no klass is found for the identifier' do
+        expect(MadID.locate("noo-getting-cold")).to be_nil
+      end
+
+      it 'returns nil if nothing is found' do
+        expect(MadID.locate("pny-no-pony-there")).to be_nil
+      end
+    end
+    describe 'locate!' do
+      it 'raises an error if no class is found' do
+        expect { MadID.locate!("noo-class-there") }.to raise_error(KeyError)
+      end
+
+      it 'raises an error if no record is found' do
+        expect { MadID.locate!("pny-class-there") }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
this changes the behaviour of locate and adds a locate! method.
the locate! method raises a KeyError error if no class is found in the
registry and an ActiveRecord::RecordNotFoundError if no record is found

the locate method simply ignores those errors and returns nil. This is
helpful when you expect the search for strange IDs but do not care if
nothing is found.

**NOTE: this changes the current API**
