### PR TITLE
make finders always accessible and default to id column

### DIFF
--- a/lib/mad_id.rb
+++ b/lib/mad_id.rb
@@ -30,11 +30,12 @@ module MadID
   end
 
   included do
-    def self.identify_with(value)
+    extend(MadID::FinderMethods)
+    def self.identify_with(value, options = {})
+      self.mad_id_column = options[:column] || 'identifier'
       @identifier = value
       MadID.registry[value.to_s] = self
       self.send(:include, MadID::IdentityMethods)
-      self.extend(MadID::FinderMethods)
     end
   end
 end

--- a/lib/mad_id/finder_methods.rb
+++ b/lib/mad_id/finder_methods.rb
@@ -1,10 +1,18 @@
 module MadID::FinderMethods
 
   def find_by_mad_id!(id)
-    find_by!(identifier: id.to_s.downcase)
+    find_by!(mad_id_column => id.to_s.downcase)
   end
   def find_by_mad_id(id)
-    find_by(identifier: id.to_s.downcase)
+    find_by(mad_id_column => id.to_s.downcase)
+  end
+
+  def mad_id_column
+    @mad_id_column || 'id'
+  end
+
+  def mad_id_column=(val)
+    @mad_id_column = val
   end
 
 end

--- a/lib/mad_id/identity_methods.rb
+++ b/lib/mad_id/identity_methods.rb
@@ -23,6 +23,13 @@ module MadID
     def to_param
       self.identifier
     end
+
+    def identifier=(value)
+      write_attribute(self.class.mad_id_column, value)
+    end
+    def identifier
+      read_attribute(self.class.mad_id_column)
+    end
   end
 
 end

--- a/spec/mad_id_spec.rb
+++ b/spec/mad_id_spec.rb
@@ -12,10 +12,25 @@ class GreatPony < Pony
   identify_with :grtpny
 end
 
+class Dog < ActiveRecord::Base
+  include MadID
+  identify_with :dog, column: 'mad_id'
+end
+
 describe MadID do
 
   it 'inserts #identify_with' do
     expect(Pony.respond_to?(:identify_with)).to be(true)
+  end
+
+  describe 'default finders' do
+    let(:pony) { Pony.create }
+    it { expect(Pony.mad_id_column).to eql('id') }
+    it { expect(Pony.find_by_mad_id(pony.id)).to eql(pony) }
+  end
+
+  describe 'configurable column' do
+    it { expect(Dog.mad_id_column).to eql('mad_id') }
   end
 
   it 'wont set any callbacks' do
@@ -47,6 +62,13 @@ describe MadID do
       before { subject.set_identifier }
       it 'will start with the #identify_with argument' do
         expect(subject.identifier).to match(/pny-.+/)
+      end
+
+      describe 'custom identifier column' do
+        subject { Dog.new }
+        before { subject.set_identifier }
+        it { expect(subject.mad_id).to_not be_nil }
+        it { expect(subject.identifier).to eql(subject.mad_id) }
       end
     end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -2,4 +2,7 @@ ActiveRecord::Schema.define(version: 1) do
   create_table "ponies", force: true do |t|
     t.string  "identifier"
   end
+  create_table "dogs", force: true do |t|
+    t.string "mad_id"
+  end
 end


### PR DESCRIPTION
when MadID is included in a class we extend that class with the finder
methods and by default search in the id column.
so we can always use the find_by_mad_id finder method. This is
especially helpful if you have mad and not mad classes.

also this makes the column configurable with the column option on the
identify_with method.

identify_with :dog, column: 'mad_id'