### PR TITLE
make overwriting to_param optional

### DIFF
--- a/lib/mad_id.rb
+++ b/lib/mad_id.rb
@@ -30,10 +30,11 @@ module MadID
   end
 
   included do
-    def self.identify_with(value)
+    def self.identify_with(value, options = {})
       @identifier = value
       MadID.registry[value.to_s] = self
       self.send(:include, MadID::IdentityMethods)
+      self.send(:include, MadID::IdentityMethods::UrlMethods) unless options[:to_param] == false # include by default
       self.extend(MadID::FinderMethods)
     end
   end

--- a/lib/mad_id/identity_methods.rb
+++ b/lib/mad_id/identity_methods.rb
@@ -20,9 +20,12 @@ module MadID
       self.identifier[0..11]
     end
 
-    def to_param
-      self.identifier
+    module UrlMethods
+      def to_param
+        self.identifier
+      end
     end
+
   end
 
 end

--- a/spec/mad_id_spec.rb
+++ b/spec/mad_id_spec.rb
@@ -9,7 +9,7 @@ class LittlePony < Pony
 end
 
 class GreatPony < Pony
-  identify_with :grtpny
+  identify_with :grtpny, to_param: false
 end
 
 describe MadID do
@@ -68,6 +68,16 @@ describe MadID do
           expect{ subject.update(identifier: 'FOOBAR')}.not_to change{ subject.reload.identifier }
         end
       end
+    end
+  end
+
+  describe "to param" do
+    let!(:little_pony) { LittlePony.create }
+    let!(:great_pony) { GreatPony.create }
+
+    it do
+      expect(little_pony.to_param).to eql(little_pony.identifier)
+      expect(great_pony.to_param).to eql(great_pony.id.to_s)
     end
   end
 


### PR DESCRIPTION
this adds the to_param option to the identify_with method.
if to_param is set to false we do not overwrite the to_param method.

example:

identify_with :foo, to_param: false